### PR TITLE
イベントに女性限定という設定ができる

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,12 @@ group :development do
   gem 'rubocop-rails', require: false
 end
 
+group :test do
+  gem 'capybara', '~> 3.23'
+  gem 'selenium-webdriver', '4.9.0'
+  gem 'webdrivers'
+end
+
 group :production do
   gem 'pg'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,15 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    capybara (3.39.2)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     diff-lcs (1.4.4)
@@ -173,6 +182,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
+    matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
     minitest (5.14.4)
@@ -286,6 +296,7 @@ GEM
       rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -296,6 +307,10 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    selenium-webdriver (4.9.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     semantic_range (3.0.0)
     sorcery (0.16.1)
       bcrypt (~> 3.1)
@@ -320,14 +335,21 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.3.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0, < 4.11)
     webpacker (5.4.3)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
+    websocket (1.2.10)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.5.1)
 
 PLATFORMS
@@ -339,6 +361,7 @@ DEPENDENCIES
   aws-sdk-s3
   bootsnap (>= 1.4.4)
   byebug
+  capybara (~> 3.23)
   draper
   enum_help
   factory_bot_rails
@@ -359,11 +382,13 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   sass-rails (>= 6)
+  selenium-webdriver (= 4.9.0)
   sorcery
   spring
   sqlite3 (~> 1.4)
   tzinfo-data
   web-console (>= 4.1.0)
+  webdrivers
   webpacker (~> 5.0)
 
 RUBY VERSION

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,2 @@
 @import 'theme.css';
+@import 'theme-child.css';

--- a/app/assets/stylesheets/theme-child.css
+++ b/app/assets/stylesheets/theme-child.css
@@ -1,0 +1,17 @@
+@charset "UTF-8";
+
+.only_woman {
+  display: inline-block;
+  font-size: 0.9em;
+  color: var(--bs-white);
+  background-color: var(--bs-primary);
+  border-radius: 5px;
+  padding: 0.6em 1.1em 0.6em 0.9em;
+  margin-bottom: 0.5em;
+}
+
+.card-title .only_woman {
+  font-size: 0.5em;
+  margin-bottom: 0;
+  margin-left: 1px;
+}

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -60,6 +60,6 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:title, :content, :held_at, :prefecture_id, :thumbnail)
+    params.require(:event).permit(:title, :content, :held_at, :prefecture_id, :thumbnail, :only_woman)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,6 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:email, :name, :password, :password_confirmation)
+    params.require(:user).permit(:email, :name, :gender, :password, :password_confirmation)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,6 +14,8 @@ class Event < ApplicationRecord
   scope :future, -> { where('held_at > ?', Time.current) }
   scope :past, -> { where('held_at <= ?', Time.current) }
 
+  validates :only_woman, inclusion: [true, false]
+
   with_options presence: true do
     validates :title
     validates :content

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,11 +14,14 @@ class User < ApplicationRecord
   has_many :notification_timings, through: :user_notification_timings
   has_one_attached :avatar
 
+  enum gender: { other: 0, woman: 1, man: 2 }
+
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
   validates :email, uniqueness: true
+  validates :gender, presence: true
 
   scope :allowing_created_event_notification,
         -> { joins(:notification_timings).merge(NotificationTiming.created_event) }
@@ -59,6 +62,10 @@ class User < ApplicationRecord
 
   def own?(event)
     event.user_id == id
+  end
+
+  def woman?
+    gender == 'woman'
   end
 
   def allow_created_event_notification?

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -4,8 +4,14 @@
       <%= image_tag event.decorate.thumbnail, class: 'card-img-top border-bottom' %>
     <% end %>
     <div class="card-body">
-      <h4 class="card-title fw-bold">
+      <h4 class="card-title fw-bold d-flex justify-content-between">
         <%= link_to event.title, event_path(event)  %>
+        <% if event.only_woman? %>
+          <span class="only_woman">
+              <i class="bi bi-exclamation-circle"></i>
+              女性限定
+            </span>
+        <% end %>
       </h4>
       <p class="card-text"><%= event.content %></p>
       <hr />

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -17,6 +17,12 @@
     <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {}, class: 'form-select' %>
   </div>
   <div class="mb-3">
+    <% if current_user.gender == 'woman' %>
+      <%= f.label :only_woman %>
+      <%= f.check_box :only_woman, {class: "form-check-input"}, true, false %>
+    <% end %>
+  </div>
+  <div class="mb-3">
     <%= f.label :thumbnail %>
     <%= f.file_field :thumbnail, class: 'form-control js-file-select-preview mb-3', accept: 'image/*', data: { target: '#preview-target' } %>
     <%= image_tag f.object.decorate.thumbnail, id: 'preview-target', class: 'w-100 border' %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -44,6 +44,12 @@
           イベントの説明
         </div>
         <div class="card-body">
+          <% if @event.only_woman? %>
+            <span class="only_woman">
+              <i class="bi bi-exclamation-circle"></i>
+              女性限定
+            </span>
+          <% end %>
           <%= simple_format @event.content %>
         </div>
       </div>
@@ -85,20 +91,22 @@
           <div class="text-center">
             <% if logged_in? %>
               <% if !current_user.owner?(@event) %>
-                <% if current_user.attend?(@event) %>
-                  <%= link_to 'キャンセルする',
-                              event_attendance_url(@event),
-                              class: 'btn btn-primary',
-                              method: :delete,
-                              data: { confirm: 'キャンセルします' }
-                  %>
-                <% else %>
-                  <%= link_to 'このもくもく会に参加する',
-                              event_attendance_url(@event),
-                              class: 'btn btn-primary',
-                              method: :post,
-                              data: { confirm: '申し込みます' }
-                  %>
+                <% if !@event.only_woman? || (@event.only_woman && current_user.woman?) %>
+                  <% if current_user.attend?(@event) %>
+                    <%= link_to 'キャンセルする',
+                                event_attendance_url(@event),
+                                class: 'btn btn-primary',
+                                method: :delete,
+                                data: { confirm: 'キャンセルします' }
+                    %>
+                  <% else %>
+                    <%= link_to 'このもくもく会に参加する',
+                                event_attendance_url(@event),
+                                class: 'btn btn-primary',
+                                method: :post,
+                                data: { confirm: '申し込みます' }
+                    %>
+                  <% end %>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -24,6 +24,10 @@
               <%= f.email_field :email, class: 'form-control' %>
             </div>
             <div class="mb-3">
+              <%= f.label :gender %>
+              <%= f.select :gender, [['女性', 'woman'], ['男性', 'man'], ['その他', 'other']], {include_blank: '選択してください'}, {class: 'form-control'} %>
+            </div>
+            <div class="mb-3">
               <%= f.label :password %>
               <%= f.password_field :password, class: 'form-control' %>
             </div>

--- a/db/migrate/20230924053700_add_gender_column_to_users.rb
+++ b/db/migrate/20230924053700_add_gender_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddGenderColumnToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :gender, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20230924053917_add_onlywoman_column_to_events.rb
+++ b/db/migrate/20230924053917_add_onlywoman_column_to_events.rb
@@ -1,0 +1,5 @@
+class AddOnlywomanColumnToEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :events, :only_woman, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_19_072358) do
+ActiveRecord::Schema.define(version: 2023_09_24_053917) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 2022_01_19_072358) do
     t.integer "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "only_woman", default: false, null: false
     t.index ["prefecture_id"], name: "index_events_on_prefecture_id"
     t.index ["user_id"], name: "index_events_on_user_id"
   end
@@ -135,6 +136,7 @@ ActiveRecord::Schema.define(version: 2022_01_19_072358) do
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "gender", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -8,4 +8,9 @@ FactoryBot.define do
     prefecture_id { [*1..47].sample }
     user
   end
+
+  trait :woman_only_event do
+    only_woman { true }
+    user { FactoryBot.create(:user, :woman_user) }
+  end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,5 +6,9 @@ FactoryBot.define do
     name { Faker::Name.name }
     password { 'password' }
     password_confirmation { 'password' }
+
+    trait :woman_user do
+      gender { :woman }
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,7 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -23,6 +24,7 @@ require 'rspec/rails'
 # require only the support files necessary.
 #
 # Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -65,4 +67,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
   config.include Sorcery::TestHelpers::Rails::Request, type: :request
+  config.include LoginMacros
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,7 +53,7 @@ RSpec.configure do |config|
   #   # is tagged with `:focus`, all examples get run. RSpec also provides
   #   # aliases for `it`, `describe`, and `context` that include `:focus`
   #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  #   config.filter_run_when_matching :focus
+  config.filter_run_when_matching :focus
   #
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :selenium, using: :headless_chrome, screen_size: [1920, 1080]
+  end
+end

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -1,0 +1,8 @@
+module LoginMacros
+  def login(user)
+    visit login_path
+    fill_in 'email', with: user.email
+    fill_in 'password', with: 'password'
+    click_button 'ログイン'
+  end
+end

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -1,0 +1,191 @@
+require 'rails_helper'
+
+RSpec.describe "Events", type: :system do
+  let(:user)  { create :user }
+  let(:event) { create :event }
+
+  describe 'event関係' do
+    context 'index' do
+      before do
+        login(user)
+      end
+
+      it '一覧ページにアクセスすると、イベント一覧を閲覧できる。' do
+        event
+        visit root_path
+        expect(page).to have_content(event.title)
+        expect(page).to have_content(event.prefecture.name)
+        expect(page).to have_content(event.user.name)
+      end
+    end
+
+    context 'new→create' do
+      before do
+        login(user)
+      end
+
+      it '新しくイベント(未来)を作成できる。トップページでそれを確認できる。"直近イベント"でそれを確認できる。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(user.name)
+        expect(page).to have_content('開催前')
+
+        visit root_path
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(user.name)
+
+        visit future_events_path
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(user.name)
+      end
+
+      it '新しくイベント(過去)を作成できる。ただしトップページでそれは確認できない。"過去イベント"において確認できる。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002014-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(user.name)
+        expect(page).to have_content('開催済み')
+
+        visit root_path
+        expect(page).not_to have_content('RUNTEQもくもく会')
+        expect(page).not_to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).not_to have_content(user.name)
+
+        visit past_events_path
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(user.name)
+      end
+
+      it 'titleが未記入だと新しいイベントは作成されない。' do
+        visit new_event_path
+        fill_in 'Title', with: ''
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会作成')
+      end
+
+      it 'contentが未記入だと新しいイベントは作成されない。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: ''
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会作成')
+      end
+
+      it 'held_atが未記入だと新しいイベントは作成されない。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: ''
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会作成')
+      end
+    end
+
+    context 'edit→update' do
+      before do
+        login(event.user)
+      end
+
+      it 'イベント(未来)を更新できる。トップページでそれを確認できる。' do
+        visit edit_event_path(event)
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(event.user.name)
+        expect(page).to have_content('開催前')
+
+        visit root_path
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(event.user.name)
+      end
+
+      it 'イベント(過去)を更新できる。ただしトップページでそれは確認できない。"過去イベント"において確認できる。' do
+        visit edit_event_path(event)
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002014-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(event.user.name)
+        expect(page).to have_content('開催済み')
+
+        visit root_path
+        expect(page).not_to have_content('RUNTEQもくもく会')
+        expect(page).not_to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).not_to have_content(event.user.name)
+
+        visit past_events_path
+        expect(page).to have_content('RUNTEQもくもく会')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会')
+        expect(page).to have_content(event.user.name)
+      end
+
+      it 'titleが未記入だと新しいイベントは作成されない。' do
+        visit edit_event_path(event)
+        fill_in 'Title', with: ''
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会編集')
+      end
+
+      it 'contentが未記入だと新しいイベントは作成されない。' do
+        visit edit_event_path(event)
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: ''
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会編集')
+      end
+
+      it 'held_atが未記入だと新しいイベントは作成されない。' do
+        visit edit_event_path(event)
+        fill_in 'Title', with: 'RUNTEQもくもく会'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会'
+        fill_in 'Held at', with: ''
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        expect(page).to have_content('もくもく会編集')
+      end
+    end
+  end
+end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe "Sessions", type: :system do
+  let(:user) { create :user }
+
+  describe 'session関係' do
+    it '登録されているユーザーでログインを行い、イベント一覧ページにリダイレクトされる。' do
+      visit login_path
+      fill_in 'email', with: user.email
+      fill_in 'password', with: 'password'
+      click_button 'ログイン'
+
+      expect(page).to have_content('もくもく会を作る')
+    end
+
+    it '登録されていないユーザーでログインを行うと、ログインページが表示される。' do
+      visit login_path
+      fill_in 'email', with: 'hogehogee4674@exmaple.com'
+      fill_in 'password', with: 'password'
+      click_button 'ログイン'
+
+      expect(page).to have_content('Sign up')
+      expect(page).not_to have_content('I agree to the Terms of Service and Privacy Policy.')
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,111 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :system do
+  describe 'Sign up関係' do
+    context '成功系' do
+      it 'Sign upを行い、ログイン処理を行うとイベント一覧ページにリダイレクトされる。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: 'password'
+        click_button '登録'
+
+        visit login_path
+        fill_in 'email', with: 'sample@example.com'
+        fill_in 'password', with: 'password'
+        click_button 'ログイン'
+
+        expect(page).to have_content('もくもく会を作る')
+      end
+
+      it 'Sign up時に性別を選ばないで登録すると、その他として登録される。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: 'password'
+        click_button '登録'
+
+        visit login_path
+        fill_in 'email', with: 'sample@example.com'
+        fill_in 'password', with: 'password'
+        click_button 'ログイン'
+
+        expect(page).to have_content('もくもく会を作る')
+        expect(User.last.gender).to eq 'other'
+      end
+
+      it 'Sign up時に性別(男性)を選んで登録することができる。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: 'password'
+        select '男性', from: 'Gender'
+        click_button '登録'
+
+        visit login_path
+        fill_in 'email', with: 'sample@example.com'
+        fill_in 'password', with: 'password'
+        click_button 'ログイン'
+
+        expect(page).to have_content('もくもく会を作る')
+        expect(User.last.gender).to eq 'man'
+      end
+
+      it 'Sign up時に性別(女性)を選んで登録することができる。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: 'password'
+        select '女性', from: 'Gender'
+        click_button '登録'
+
+        visit login_path
+        fill_in 'email', with: 'sample@example.com'
+        fill_in 'password', with: 'password'
+        click_button 'ログイン'
+
+        expect(page).to have_content('もくもく会を作る')
+        expect(User.last.gender).to eq 'woman'
+      end
+    end
+
+    context '失敗系' do
+      it 'passwordが未入力だと。Sign upページが表示される。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: ''
+        fill_in 'Password confirmation', with: 'password'
+        click_button '登録'
+
+        expect(page).to have_content('I agree to the Terms of Service and Privacy Policy.')
+      end
+
+      it 'password_confirmationが未入力だと。Sign upページが表示される。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: 'password'
+        fill_in 'Password confirmation', with: ''
+        click_button '登録'
+
+        expect(page).to have_content('I agree to the Terms of Service and Privacy Policy.')
+      end
+
+      it 'password, password_confirmationが未入力だと。Sign upページが表示される。' do
+        visit signup_path
+        fill_in 'Name', with: 'らんてくん'
+        fill_in 'Email', with: 'sample@example.com'
+        fill_in 'Password', with: ''
+        fill_in 'Password confirmation', with: ''
+        click_button '登録'
+
+        expect(page).to have_content('I agree to the Terms of Service and Privacy Policy.')
+      end
+    end
+  end
+end

--- a/spec/system/woman_only_events_spec.rb
+++ b/spec/system/woman_only_events_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe "WomanOnlyEvents", type: :system do
+  let(:user)  { create :user }
+  let(:woman) { create :user, :woman_user }
+  let(:event) { create :event }
+  let(:woman_only_event) { create :event, :woman_only_event }
+
+  describe '女性限定event' do
+    context '女性以外のユーザーがログインした場合' do
+      before do
+        woman_only_event
+        login(user)
+      end
+
+      it '一覧に"女性限定"の表記のイベントがある。' do
+        visit root_path
+        expect(page).to have_content(woman_only_event.title)
+        expect(page).to have_content('女性限定')
+      end
+
+      it '"女性限定"イベントには参加できない。' do
+        visit event_path(woman_only_event)
+        expect(page).to have_content(woman_only_event.title)
+        expect(page).to have_content('女性限定')
+        expect(page).not_to have_content('このもくもく会に参加する')
+      end
+
+      it '新規イベント作成時に"Only woman"チェックボックスが表示されない。' do
+        visit new_event_path
+        expect(page).to have_content('もくもく会作成')
+        expect(page).not_to have_content('Only woman')
+      end
+    end
+
+    context '女性ユーザーがログインした場合' do
+      before do
+        woman_only_event
+        login(woman)
+      end
+
+      it '一覧に"女性限定"の表記のイベントがある。' do
+        visit root_path
+        expect(page).to have_content(woman_only_event.title)
+        expect(page).to have_content('女性限定')
+      end
+
+      it '"女性限定"イベントに参加できる。' do
+        visit event_path(woman_only_event)
+        expect(page).to have_content(woman_only_event.title)
+        expect(page).to have_content('女性限定')
+        expect(page).to have_content('このもくもく会に参加する')
+
+        click_link 'このもくもく会に参加する'
+      end
+
+      it '"女性限定"イベントを作成できる。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会-woman-'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会-woman-'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        find('#event_only_woman').click
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会-woman-')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会-woman-')
+        expect(page).to have_content(woman.name)
+        expect(page).to have_content('開催前')
+        expect(page).to have_content('女性限定')
+
+        visit root_path
+        expect(page).to have_content('RUNTEQもくもく会-woman-')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会-woman-')
+        expect(page).to have_content(woman.name)
+        expect(page).to have_content('女性限定')
+      end
+
+      it '"女性限定"イベントを更新できる。' do
+        visit new_event_path
+        fill_in 'Title', with: 'RUNTEQもくもく会-vol2-'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会-vol2-'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        click_button '登録'
+
+        visit edit_event_path(woman.events.last)
+        fill_in 'Title', with: 'RUNTEQもくもく会-woman vol2-'
+        fill_in 'Content', with: '渋谷にあるRUNTEQ教室でもくもく会-woman vol2-'
+        fill_in 'Held at', with: '002055-10-02-1300'
+        select '東京都', from: 'Prefecture'
+        find('#event_only_woman').click
+        click_button '登録'
+
+        expect(page).to have_content('RUNTEQもくもく会-woman vol2-')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会-woman vol2-')
+        expect(page).to have_content(woman.name)
+        expect(page).to have_content('開催前')
+        expect(page).to have_content('女性限定')
+
+        visit root_path
+        expect(page).to have_content('RUNTEQもくもく会-woman vol2-')
+        expect(page).to have_content('渋谷にあるRUNTEQ教室でもくもく会-woman vol2-')
+        expect(page).to have_content(woman.name)
+        expect(page).to have_content('女性限定')
+      end
+    end
+  end
+end

--- a/spec/system/woman_users_spec.rb
+++ b/spec/system/woman_users_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe "WomanUsers", type: :system do
+  let(:user)  { create :user }
+  let(:woman) { create :user, :woman}
+  let(:event) { create :event }
+
+  describe 'womanがログインした場合' do
+    before do
+      login(woman)
+      event
+    end
+
+    it '一覧ページにアクセスすると、イベント一覧にアクセスでき、イベント(一般)を閲覧できる。' do
+      visit root_path
+      expect(page).to have_content(event.title)
+      expect(page).to have_content(event.prefecture.name)
+      expect(page).to have_content(event.user.name)
+    end
+
+    it '一般イベントに参加することができる。' do
+      visit event_path(event)
+      expect(page).to have_content(event.title)
+      expect(page).to have_content(event.user.name)
+      expect(page).not_to have_content('女性限定')
+      expect(page).to have_content('このもくもく会に参加する')
+    end
+  end
+end


### PR DESCRIPTION
## 選択した事業課題：
サービス登録者数の内、男性60%に対して、女性は40%。一方で、サービス内のもくもく会に参加した人の比率は、男性90%：女性10%と大きな差が出ています。もっと女性が使いやすいようなサービス設計にする必要があるのではないか？

## 概要：
- ユーザの情報に性別が登録できるようにしました。
- ユーザの性別が女性の場合、女性限定イベントを作成できるようにしました。
- 女性限定イベントには女性ユーザしか「このもくもく会に参加する」ボタンが表示されないようにしました。
- イベント一覧・詳細画面で女性限定イベントには「女性限定」と目印が表示されるようにしました。

## 自動テスト結果：
[![Image from Gyazo](https://i.gyazo.com/e8809ceca2d091a33a3b408e2af96c20.png)](https://gyazo.com/e8809ceca2d091a33a3b408e2af96c20)